### PR TITLE
Rebrand to Code Vitals and prepare the first Marketplace release

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
       {
         "command": "codeVitals.selectCommand",
         "title": "Code Vitals: Select Command"
+      },
+      {
+        "command": "codeVitals.toggleRevealOnFailure",
+        "title": "Code Vitals: Toggle Auto-Open Terminal on Failure"
       }
     ],
     "configuration": {

--- a/src/cargo.ts
+++ b/src/cargo.ts
@@ -1,10 +1,10 @@
 // Cargo's machine-readable message stream is our source of truth for build
 // status. Everything here is pure and VS Code-free, so it's unit-testable.
 
-export type CodePulseCommand = 'check' | 'run' | 'clippy' | 'test';
+export type CargoCommand = 'check' | 'run' | 'clippy' | 'test';
 
 // `run` and `test` keep a process alive after the build; `check`/`clippy` don't.
-export function isLongRunning(command: CodePulseCommand): boolean {
+export function isLongRunning(command: CargoCommand): boolean {
 	return command === 'run' || command === 'test';
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
-import { CodePulseCommand, isLongRunning, parseCargoLine } from './cargo';
+import { CargoCommand, isLongRunning, parseCargoLine } from './cargo';
 import { PtyTerminal } from './terminal';
 import { State, StatusBar } from './statusBar';
 
@@ -13,10 +13,11 @@ let output: PtyTerminal | undefined;
 let log: vscode.OutputChannel | undefined;
 let currentChild: ChildProcessWithoutNullStreams | undefined;
 let saveDebounce: NodeJS.Timeout | undefined;
-let activeCommand: CodePulseCommand = 'run';
+let activeCommand: CargoCommand = 'run';
 let buildStartedAt = 0;
 let errorCount = 0;
 let warningCount = 0;
+let lastState: State = State.Idle;
 
 export function activate(context: vscode.ExtensionContext): void {
 	log = vscode.window.createOutputChannel('Code Vitals');
@@ -30,6 +31,7 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand('codeVitals.stop', () => stop(true)),
 		vscode.commands.registerCommand('codeVitals.showOutput', () => output?.reveal()),
 		vscode.commands.registerCommand('codeVitals.selectCommand', () => selectCommand()),
+		vscode.commands.registerCommand('codeVitals.toggleRevealOnFailure', () => toggleRevealOnFailure()),
 	);
 
 	// Rebuild when a Rust file is saved, debounced so "save all" fires once.
@@ -65,10 +67,32 @@ function logLine(message: string): void {
 }
 
 function setStatus(state: State): void {
+	lastState = state;
 	const command = state === State.Idle
-		? (getConfig().get<string>('command', 'run') as CodePulseCommand)
+		? (getConfig().get<string>('command', 'run') as CargoCommand)
 		: activeCommand;
-	statusBar.render(state, { command, startedAt: buildStartedAt, errors: errorCount, warnings: warningCount });
+	statusBar.render(state, {
+		command,
+		startedAt: buildStartedAt,
+		errors: errorCount,
+		warnings: warningCount,
+		revealOnFailure: getConfig().get<boolean>('revealTerminalOnFailure', true),
+	});
+}
+
+// Flip the "open the terminal automatically on failure" setting. Reachable from
+// the status bar tooltip and the command palette.
+async function toggleRevealOnFailure(): Promise<void> {
+	const cfg = getConfig();
+	const next = !cfg.get<boolean>('revealTerminalOnFailure', true);
+	const folder = vscode.workspace.workspaceFolders?.[0];
+	const target = folder
+		? vscode.ConfigurationTarget.Workspace
+		: vscode.ConfigurationTarget.Global;
+	await cfg.update('revealTerminalOnFailure', next, target);
+	logLine(`auto-open on failure: ${next ? 'on' : 'off'}`);
+	vscode.window.showInformationMessage(`Code Vitals: auto-open terminal on failure is now ${next ? 'on' : 'off'}.`);
+	setStatus(lastState);
 }
 
 // Pick a cargo command, save it, and rebuild.
@@ -111,7 +135,7 @@ function start(reveal: boolean): void {
 	stop(false); // kill any in-flight build/server before starting a new one
 
 	const config = getConfig();
-	const command = config.get<string>('command', 'run') as CodePulseCommand;
+	const command = config.get<string>('command', 'run') as CargoCommand;
 	const cargoPath = config.get<string>('cargoPath', 'cargo');
 	const cwd = folder.uri.fsPath;
 	activeCommand = command;

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { CodePulseCommand } from './cargo';
+import { CargoCommand } from './cargo';
 
 export enum State {
 	Idle,      // flatline, nothing running
@@ -10,10 +10,11 @@ export enum State {
 }
 
 export interface StatusContext {
-	command: CodePulseCommand;
+	command: CargoCommand;
 	startedAt: number; // Date.now() at build start, for elapsed time
 	errors: number;
 	warnings: number;
+	revealOnFailure: boolean;
 }
 
 // The icon mirrors the project's namesake: pulse when something is alive,
@@ -40,33 +41,48 @@ export class StatusBar {
 		this.item.backgroundColor = undefined;
 		const cmd = ctx.command;
 		const extra = countsSuffix(ctx);
+		let message = '';
 		switch (state) {
 			case State.Idle:
 				this.item.text = '$(dash)';
-				this.item.tooltip = `Code Vitals: idle. Click to run cargo ${cmd}.`;
+				message = `Code Vitals: idle. Click to run cargo ${cmd}.`;
 				break;
 			case State.Building:
 				this.item.text = '$(sync~spin)';
-				this.item.tooltip = `Code Vitals: building cargo ${cmd}.`;
+				message = `Code Vitals: building cargo ${cmd}.`;
 				break;
 			case State.Running:
 				this.item.text = '$(pulse)';
-				this.item.tooltip = `Code Vitals: cargo ${cmd} running. Click to restart.`;
+				message = `Code Vitals: cargo ${cmd} running. Click to restart.`;
 				break;
 			case State.Done: {
 				this.item.text = '$(check)';
 				const verb = cmd === 'run' ? 'ran OK' : cmd === 'test' ? 'tests passed' : 'passed';
-				this.item.tooltip = `Code Vitals: cargo ${cmd} ${verb} in ${elapsed(ctx)}${extra}. Click to run again.`;
+				message = `Code Vitals: cargo ${cmd} ${verb} in ${elapsed(ctx)}${extra}. Click to run again.`;
 				break;
 			}
 			case State.Failed:
 				this.item.text = '$(error)';
-				this.item.tooltip = `Code Vitals: cargo ${cmd} failed in ${elapsed(ctx)}${extra}. Click to rebuild.`;
+				message = `Code Vitals: cargo ${cmd} failed in ${elapsed(ctx)}${extra}. Click to rebuild.`;
 				this.item.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
 				break;
 		}
+		this.item.tooltip = tooltip(message, ctx.revealOnFailure);
 		this.log(`icon -> ${label(state)}`);
 	}
+}
+
+// Trusted markdown so the action link is clickable on hover.
+function tooltip(message: string, revealOnFailure: boolean): vscode.MarkdownString {
+	const md = new vscode.MarkdownString();
+	md.isTrusted = true;
+	md.appendMarkdown(message);
+	md.appendMarkdown('\n\n');
+	const action = revealOnFailure
+		? 'Disable auto-open terminal on failure'
+		: 'Enable auto-open terminal on failure';
+	md.appendMarkdown(`[${action}](command:codeVitals.toggleRevealOnFailure)`);
+	return md;
 }
 
 function label(state: State): string {

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -2,16 +2,16 @@ import * as vscode from 'vscode';
 import { CargoCommand } from './cargo';
 
 export enum State {
-	Idle,      // flatline, nothing running
-	Building,  // spinner
-	Running,   // pulse, a run/test process is alive
-	Done,      // check, finished successfully
-	Failed,    // red cross
+	Idle,
+	Building,
+	Running,
+	Done,
+	Failed,
 }
 
 export interface StatusContext {
 	command: CargoCommand;
-	startedAt: number; // Date.now() at build start, for elapsed time
+	startedAt: number;
 	errors: number;
 	warnings: number;
 	revealOnFailure: boolean;
@@ -23,7 +23,6 @@ export class StatusBar {
 	private readonly item: vscode.StatusBarItem;
 
 	constructor(private readonly log: (message: string) => void) {
-		// Left side, where the eye lands first; priority sets the order.
 		this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 100);
 		this.item.name = 'Code Vitals';
 		this.item.command = 'codeVitals.start';
@@ -45,25 +44,25 @@ export class StatusBar {
 		switch (state) {
 			case State.Idle:
 				this.item.text = '$(dash)';
-				message = `Code Vitals: idle. Click to run cargo ${cmd}.`;
+				message = `Idle. Click to run cargo ${cmd}.`;
 				break;
 			case State.Building:
 				this.item.text = '$(sync~spin)';
-				message = `Code Vitals: building cargo ${cmd}.`;
+				message = `Building cargo ${cmd}.`;
 				break;
 			case State.Running:
 				this.item.text = '$(pulse)';
-				message = `Code Vitals: cargo ${cmd} running. Click to restart.`;
+				message = `Running cargo ${cmd}. Click to restart.`;
 				break;
 			case State.Done: {
 				this.item.text = '$(check)';
 				const verb = cmd === 'run' ? 'ran OK' : cmd === 'test' ? 'tests passed' : 'passed';
-				message = `Code Vitals: cargo ${cmd} ${verb} in ${elapsed(ctx)}${extra}. Click to run again.`;
+				message = `cargo ${cmd} ${verb} in ${elapsed(ctx)}${extra}. Click to run again.`;
 				break;
 			}
 			case State.Failed:
 				this.item.text = '$(error)';
-				message = `Code Vitals: cargo ${cmd} failed in ${elapsed(ctx)}${extra}. Click to rebuild.`;
+				message = `cargo ${cmd} failed in ${elapsed(ctx)}${extra}. Click to rebuild.`;
 				this.item.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
 				break;
 		}


### PR DESCRIPTION
## What this is

Rebrands the extension from "Code Pulse" (that display name was already taken
on the Marketplace) to **Code Vitals**, wires up everything needed to publish,
and adds a small status bar feature.

## Changes

**Rebrand**
- `name` is now `code-vitals`, display name "Code Vitals".
- Command and setting IDs moved from `codePulse.*` to `codeVitals.*`.
- Updated every label users see: command titles, the settings section, the
  status bar, the terminal, the output channel, and all tooltips.
- Renamed the internal `CodePulseCommand` type to `CargoCommand`.
- README and CHANGELOG updated to match.

**Marketplace prep**
- Set `publisher` to `MustafaAnsari`.
- Added a `repository` field and a 128x128 heartbeat icon (`icon.png`).

**New feature**
- The status bar tooltip now has a clickable link to turn the "open the
  terminal automatically on failure" behavior on or off, backed by a new
  `codeVitals.toggleRevealOnFailure` command (also in the Command Palette).

## Why

"Code Pulse" was rejected as a duplicate display name. The new name is language
neutral on purpose: the plan is to add Go and JavaScript/TypeScript later
through a provider layer. This release ships Rust support.

## Testing
- [ ] `npm run compile` is clean
- [ ] `npm test` passes
- [ ] In the Extension Development Host: pulse while running, check on success,
      red on failure, and the tooltip link disables and re-enables auto-open

## Notes
The GitHub repo is still named `code-pulse-server-status`, so the `repository`
URL points there. Renaming the repo to `code-vitals` is a sensible next step.